### PR TITLE
Make start-stop-daemon fork in the background

### DIFF
--- a/data/mausberry-switch.init
+++ b/data/mausberry-switch.init
@@ -44,7 +44,7 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
-	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec --background $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2
 	# Add code here, if necessary, that waits for the process to be ready


### PR DESCRIPTION
The mausberry-switch binary doesn't seem to be forking by itself.