### PR TITLE
Cross-compile armhf package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,10 +52,11 @@ jobs:
               -f \
               -s dir \
               -t deb \
+              -a armhf \
               -n mausberry-switch \
               -v 0.8 \
               -C /tmp/installdir \
-              -p mausberry-switch_VERSION_armhf.deb \
+              -p mausberry-switch_VERSION_ARCH.deb \
               -d "libglib2.0-0 >= 2.42" \
               --deb-systemd data/mausberry-switch.service \
               usr/bin etc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: debian:buster
+      - image: debian:buster-slim
         environment:
           CFLAGS: -O2 -pipe -fstack-protector-strong -fno-plt
           CPPFLAGS: -D_FORTIFY_SOURCE=2
@@ -67,4 +67,4 @@ jobs:
             tar tvf data.tar.gz
 
       - store_artifacts:
-          path: mausberry-switch_*.deb
+          path: mausberry-switch_0.8_armhf.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,12 @@ jobs:
     docker:
       - image: debian:buster
         environment:
-          CC: /usr/bin/arm-linux-gnueabihf-gcc
-          LD: /usr/bin/arm-linux-gnueabihf-ld
           CFLAGS: -O2 -pipe -fstack-protector-strong -fno-plt
           CPPFLAGS: -D_FORTIFY_SOURCE=2
           DEBIAN_FRONTEND: noninteractive
           LDFLAGS: -Wl,-O1,--sort-common,--as-needed,-z,relro
+          PKG_CONFIG_ALLOW_CROSS: 1
+          PKG_CONFIG_PATH: /usr/lib/arm-linux-gnueabihf/pkgconfig/
 
     steps:
       - checkout
@@ -17,8 +17,9 @@ jobs:
       - run:
           name: Install dependencies
           command: |
+            dpkg --add-architecture armhf
             apt-get update -q
-            apt-get install -qy crossbuild-essential-armhf dh-autoreconf libglib2.0-dev ruby ruby-dev
+            apt-get install -qy crossbuild-essential-armhf dh-autoreconf libglib2.0-dev:armhf ruby ruby-dev
 
       - run:
           name: Create install directory
@@ -34,7 +35,7 @@ jobs:
 
       - run:
           name: Configure
-          command: ./configure --prefix=/usr --sysconfdir=/etc
+          command: ./configure --prefix=/usr --sysconfdir=/etc --build=x86_64-linux-gnu --host=arm-linux-gnueabihf
 
       - run:
           name: Make
@@ -54,7 +55,7 @@ jobs:
               -n mausberry-switch \
               -v 0.8 \
               -C /tmp/installdir \
-              -p mausberry-switch_VERSION_ARCH.deb \
+              -p mausberry-switch_VERSION_armhf.deb \
               -d "libglib2.0-0 >= 2.42" \
               --deb-systemd data/mausberry-switch.service \
               usr/bin etc
@@ -64,3 +65,6 @@ jobs:
           command: |
             ar x mausberry-switch_*.deb
             tar tvf data.tar.gz
+
+      - store_artifacts:
+          path: mausberry-switch_*.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,13 @@ jobs:
     docker:
       - image: debian:buster
         environment:
+          CC: /usr/bin/arm-linux-gnueabihf-gcc
+          LD: /usr/bin/arm-linux-gnueabihf-ld
+          CFLAGS: -O2 -pipe -fstack-protector-strong -fno-plt
+          CPPFLAGS: -D_FORTIFY_SOURCE=2
           DEBIAN_FRONTEND: noninteractive
+          LDFLAGS: -Wl,-O1,--sort-common,--as-needed,-z,relro
+
     steps:
       - checkout
 
@@ -12,7 +18,7 @@ jobs:
           name: Install dependencies
           command: |
             apt-get update -q
-            apt-get install -qy build-essential dh-autoreconf libglib2.0-dev ruby ruby-dev
+            apt-get install -qy crossbuild-essential-armhf dh-autoreconf libglib2.0-dev ruby ruby-dev
 
       - run:
           name: Create install directory
@@ -33,10 +39,6 @@ jobs:
       - run:
           name: Make
           command: make
-
-      - run:
-          name: Test
-          command: make check
 
       - run:
           name: Make install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mausberry-switch
 
-[![Build Status](https://travis-ci.org/t-richards/mausberry-switch.svg?branch=master)](https://travis-ci.org/t-richards/mausberry-switch)
+[![CircleCI](https://circleci.com/gh/t-richards/mausberry-switch.svg?style=shield)](https://circleci.com/gh/t-richards/mausberry-switch)
 
 This is a daemon for [Raspberry Pi][rpi] devices that monitors GPIO pins 23 and
 24, waiting for a low signal from a [Mausberry Circuits switch][mausberry-circuits]

--- a/README.md
+++ b/README.md
@@ -59,12 +59,23 @@ Here's the output of `top` showing the CPU and RAM usage of this program:
 
 ## Alright, I'm convinced. How do I install this thing?
 
-Please see [doc/building.md][build-doc] for instructions on compiling and
-installing this package.
+Fetch and install the package directly on your Pi:
+
+```bash
+# Download the package
+wget https://github.com/t-richards/mausberry-switch/releases/download/0.8/mausberry-switch_0.8_armhf.deb
+
+# Install the package
+sudo dpkg -i mausberry-switch*.deb
+sudo apt-get -f install
+```
+
+Please also see the [releases][releases] section on GitHub.
 
 [build-doc]: doc/building.md
 [gpio-sysfs]: https://www.kernel.org/doc/Documentation/gpio/sysfs.txt
 [mausberry-circuits]: http://mausberrycircuits.com/
 [mausberry-script]: http://files.mausberrycircuits.com/setup.sh
+[releases]: https://github.com/t-richards/mausberry-switch/releases
 [rpi]: http://www.raspberrypi.org/
 [wasted-clock]: http://www.raspberrypi.org/phpBB3/viewtopic.php?t=63561

--- a/README.md
+++ b/README.md
@@ -72,6 +72,36 @@ sudo apt-get -f install
 
 Please also see the [releases][releases] section on GitHub.
 
+## Usage
+
+The `mausberry-switch` service will be automatically enabled and started when you install the package.
+
+To stop or disable the service, the appropriate `systemctl` command should be used. For example:
+
+```bash
+# Stop the service temporarily
+sudo systemctl stop mausberry-switch
+
+# Disable the service from automatically starting at boot
+sudo systemctl disable mausberry-switch
+```
+
+Configuration options (such as input/output pins, shutdown command/delay) are available in the primary configuration file, `/etc/mausberry-switch.conf`.
+
+After changing this file, some values may be hot-reloaded:
+
+```bash
+sudo systemctl reload mausberry-switch
+```
+
+While others may require a full service restart:
+
+```bash
+sudo systemctl restart mausberry-switch
+```
+
+Please see the configuration file for documentation on each supported option.
+
 [build-doc]: doc/building.md
 [gpio-sysfs]: https://www.kernel.org/doc/Documentation/gpio/sysfs.txt
 [mausberry-circuits]: http://mausberrycircuits.com/

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_PROG_CC
 AC_PROG_INSTALL
 
 # Libraries
-PKG_CHECK_MODULES(GLIB, glib-2.0>=2.42)
+PKG_CHECK_MODULES([GLIB, glib-2.0 >= 2.42)
 
 # Headers
 AC_CHECK_HEADERS([errno.h fcntl.h poll.h stdlib.h unistd.h])

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
-AC_PREREQ(2.63)
+AC_PREREQ(2.69)
 
-AC_INIT([Mausberry Switch], 0.6)
+AC_INIT([Mausberry Switch], 0.8)
 AC_CONFIG_SRCDIR(src)
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
@@ -13,7 +13,7 @@ AC_PROG_CC
 AC_PROG_INSTALL
 
 # Libraries
-PKG_CHECK_MODULES(GLIB, glib-2.0)
+PKG_CHECK_MODULES(GLIB, glib-2.0>=2.42)
 
 # Headers
 AC_CHECK_HEADERS([errno.h fcntl.h poll.h stdlib.h unistd.h])

--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_PROG_CC
 AC_PROG_INSTALL
 
 # Libraries
-PKG_CHECK_MODULES([GLIB, glib-2.0 >= 2.42)
+PKG_CHECK_MODULES(GLIB, glib-2.0 >= 2.42)
 
 # Headers
 AC_CHECK_HEADERS([errno.h fcntl.h poll.h stdlib.h unistd.h])

--- a/data/mausberry-switch.conf
+++ b/data/mausberry-switch.conf
@@ -1,6 +1,7 @@
 # [Pins] section: GPIO pin configuration.
-# These values are only read once at service initialization time and may not be
-# changed on-the-fly. You must fully restart the service to use the new values.
+# These values are static and WILL NOT be hot-reloaded.
+# You must fully restart the service to use the new values.
+# (systemctl restart mausberry-switch)
 [Pins]
 
 #
@@ -20,8 +21,8 @@ Out=23
 In=24
 
 # [Config] Section: General configuration settings.
-# These values may be changed on-the-fly, and will be reloaded if the service
-# receives a SIGHUP (systemctl reload mausberry-switch).
+# These values WILL be hot-reloaded when the service receives a SIGHUP.
+# (systemctl reload mausberry-switch).
 [Config]
 
 #

--- a/data/mausberry-switch.conf
+++ b/data/mausberry-switch.conf
@@ -22,7 +22,7 @@ In=24
 
 # [Config] Section: General configuration settings.
 # These values WILL be hot-reloaded when the service receives a SIGHUP.
-# (systemctl reload mausberry-switch).
+# (systemctl reload mausberry-switch)
 [Config]
 
 #

--- a/data/mausberry-switch.service
+++ b/data/mausberry-switch.service
@@ -4,6 +4,7 @@ After=syslog.target
 
 [Service]
 ExecStart=/usr/bin/mausberry-switch
+ExecReload=/bin/kill -HUP $MAINPID
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main.c
+++ b/src/main.c
@@ -15,9 +15,8 @@ gboolean maus_handle_sighup(gpointer user_data)
     return G_SOURCE_CONTINUE;
 }
 
-gboolean maus_handle_termint(gpointer user_data)
+gboolean maus_handle_termint(gpointer _unused)
 {
-    MausPrivate *priv = (MausPrivate*) user_data;
     g_fprintf(stderr, "Received SIGTERM or SIGINT, exiting.\n");
     exit(EXIT_SUCCESS);
 }
@@ -29,8 +28,8 @@ int main(int argc, char *argv[])
 
     // Set up signal handlers
     g_unix_signal_add(SIGHUP, (GSourceFunc) maus_handle_sighup, priv);
-    g_unix_signal_add(SIGINT, (GSourceFunc) maus_handle_termint, priv);
-    g_unix_signal_add(SIGINT, (GSourceFunc) maus_handle_termint, priv);
+    g_unix_signal_add(SIGINT, (GSourceFunc) maus_handle_termint, NULL);
+    g_unix_signal_add(SIGTERM, (GSourceFunc) maus_handle_termint, NULL);
 
     // Parse config
     if(!maus_reload_config(priv)) {


### PR DESCRIPTION
This PR produces a `.deb` package for the Raspberry Pi `armhf` architecture.