### PR TITLE
fix: invalid argument

### DIFF
--- a/data/mausberry-switch.service
+++ b/data/mausberry-switch.service
@@ -1,9 +1,10 @@
 [Unit]
 Description=Mausberry switch GPIO monitoring daemon
-After=syslog.target
 
 [Service]
 ExecStart=/usr/bin/mausberry-switch
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target

--- a/src/main.c
+++ b/src/main.c
@@ -9,15 +9,17 @@ int main(int argc, char *argv[]) {
   MausPrivate *priv = g_new0(MausPrivate, 1);
 
   // Parse and print config
-  if (!maus_load_config(priv)) {
-    return EXIT_FAILURE;
-  }
+  maus_load_config(priv);
 
   // Set up pins
   maus_setup_gpio(priv);
 
   // Wait for switch state to change
   int result = maus_gpio_wait(priv->pin_out);
+  if (result == -1) {
+    g_fprintf(stderr, "Failed to wait on power switch. Exiting.\n");
+    return EXIT_FAILURE;
+  }
   g_printf("Power switch pressed. (received a %d)\n", result);
 
   // Optional shutdown delay
@@ -35,8 +37,6 @@ int main(int argc, char *argv[]) {
     g_fprintf(stderr, "Error executing shutdown command: %s\n",
               strerror(errno_sv));
   }
-
-  g_free(priv);
 
   return EXIT_SUCCESS;
 }

--- a/src/maus.c
+++ b/src/maus.c
@@ -247,6 +247,9 @@ void maus_load_config(MausPrivate *priv) {
     priv->shutdown_delay = 0;
     priv->pin_out = 23;
     priv->pin_in = 24;
+
+    maus_print_config(priv);
+
     return;
   }
 
@@ -258,13 +261,17 @@ void maus_load_config(MausPrivate *priv) {
   priv->pin_in = g_key_file_get_integer(config_file, "Pins", "In", NULL);
   priv->pin_out = g_key_file_get_integer(config_file, "Pins", "Out", NULL);
 
+  maus_print_config(priv);
+}
+
+void maus_print_config(MausPrivate *priv) {
   // Print configuration
-  g_printf("== Mausberry Switch Configuration ==\n");
-  g_printf("Shutdown command: '%s'\n", priv->shutdown_command);
-  g_printf("Shutdown delay: %d\n", priv->shutdown_delay);
-  g_printf("Pin IN: %d\n", priv->pin_in);
-  g_printf("Pin OUT: %d\n", priv->pin_out);
-  g_printf("== End Mausberry Switch Configuration ==\n");
+  g_printf("\n== Mausberry Switch Configuration ==\n");
+  g_printf("Command:  %s\n", priv->shutdown_command);
+  g_printf("Delay  :  %d\n", priv->shutdown_delay);
+  g_printf("Pin IN :  %d\n", priv->pin_in);
+  g_printf("Pin OUT:  %d\n", priv->pin_out);
+  g_printf("== End Mausberry Switch Configuration ==\n\n");
 }
 
 gboolean maus_setup_gpio(MausPrivate *priv) {

--- a/src/maus.c
+++ b/src/maus.c
@@ -265,28 +265,31 @@ gboolean maus_load_config(MausPrivate *priv) {
 }
 
 gboolean maus_setup_gpio(MausPrivate *priv) {
-  // Reset GPIO pins
-  if (-1 == maus_gpio_unexport(priv->pin_out) ||
-      -1 == maus_gpio_unexport(priv->pin_in))
-    g_fprintf(stderr, "GPIO pins not reset.\n");
-
   // Enable GPIO pins
-  if (-1 == maus_gpio_export(priv->pin_out) ||
-      -1 == maus_gpio_export(priv->pin_in))
-    g_fprintf(stderr, "GPIO pins not exported.\n");
+  if (-1 == maus_gpio_export(priv->pin_out)) {
+    g_fprintf(stderr, "Failed to enable output pin.\n");
+  }
+  if (-1 == maus_gpio_export(priv->pin_in)) {
+    g_fprintf(stderr, "Failed to enable input pin.\n");
+  }
 
   // Set GPIO directions
-  if (-1 == maus_gpio_direction_in(priv->pin_out) ||
-      -1 == maus_gpio_direction_out(priv->pin_in))
-    g_fprintf(stderr, "GPIO directions not set.\n");
+  if (-1 == maus_gpio_direction_in(priv->pin_out)) {
+    g_fprintf(stderr, "Failed set direction of output pin.\n");
+  }
+  if (-1 == maus_gpio_direction_out(priv->pin_in)) {
+    g_fprintf(stderr, "Failed set direction of input pin.\n");
+  }
 
   // Initialize switch state
-  if (-1 == maus_gpio_write(priv->pin_in, VALUE_HIGH))
+  if (-1 == maus_gpio_write(priv->pin_in, VALUE_HIGH)) {
     g_fprintf(stderr, "GPIO not initialized.\n");
+  }
 
   // Register 'out' pin as interrupt source
-  if (-1 == maus_gpio_interrupt(priv->pin_out))
+  if (-1 == maus_gpio_interrupt(priv->pin_out)) {
     g_fprintf(stderr, "GPIO not configured as interrupt.\n");
+  }
 
   return TRUE;
 }

--- a/src/maus.h
+++ b/src/maus.h
@@ -25,7 +25,7 @@ int maus_gpio_direction_out(gint pin);
 int maus_gpio_interrupt(gint pin);
 int maus_gpio_wait(gint pin);
 int maus_gpio_write(gint pin, gint value);
-gboolean maus_load_config(MausPrivate *priv);
+void maus_load_config(MausPrivate *priv);
 gboolean maus_setup_gpio(MausPrivate *priv);
 
 #endif

--- a/src/maus.h
+++ b/src/maus.h
@@ -18,14 +18,15 @@ typedef struct {
 
 typedef enum { VALUE_LOW = 0, VALUE_HIGH = 1 } MausGpioValue;
 
-int maus_gpio_export(gint pin);
-int maus_gpio_unexport(gint pin);
+gboolean maus_setup_gpio(MausPrivate *priv);
 int maus_gpio_direction_in(gint pin);
 int maus_gpio_direction_out(gint pin);
+int maus_gpio_export(gint pin);
 int maus_gpio_interrupt(gint pin);
+int maus_gpio_unexport(gint pin);
 int maus_gpio_wait(gint pin);
 int maus_gpio_write(gint pin, gint value);
 void maus_load_config(MausPrivate *priv);
-gboolean maus_setup_gpio(MausPrivate *priv);
+void maus_print_config(MausPrivate *priv);
 
 #endif

--- a/tests/test_maus.c
+++ b/tests/test_maus.c
@@ -2,7 +2,7 @@
 #include <locale.h>
 #include <stdlib.h>
 
-void test_exit_non_zero_with_invalid_configuration_file()
+void test_exit_non_zero_without_gpio()
 {
     int exitstatus = system("../src/mausberry-switch");
     g_assert_cmpint(WEXITSTATUS(exitstatus), ==, 1);
@@ -16,9 +16,8 @@ main (int argc, char *argv[])
     g_test_init(&argc, &argv, NULL);
     g_test_bug_base("https://github.com/t-richards/mausberry-switch/issues");
 
-    // Define the tests.
     g_test_add_func("/libmaus/test_exit_nonzero",
-                    test_exit_non_zero_with_invalid_configuration_file);
+                    test_exit_non_zero_without_gpio);
 
     return g_test_run();
 }


### PR DESCRIPTION
When starting up, the service attempts to unexport both pins. It fails after attempting to unexport the input pin, and then does not attempt to unexport the output pin.

This pin unexporting is not necessary, and probably not desirable because it might trigger an early shutdown on a system whose pins are already exported.

Additionally, the return values of each operation should be checked individually to avoid the short-circuit evaluation which can (and does) cause parts of the setup process to only halfway apply.

```
== Mausberry Switch Configuration ==
Shutdown command: 'systemctl poweroff'
Shutdown delay: 0
Pin IN: 24
Pin OUT: 23
== End Mausberry Switch Configuration ==
Failed to unexport pin 23: Invalid argument
GPIO pins not reset.
```